### PR TITLE
koverton ip-address redo

### DIFF
--- a/docs/router-details.md
+++ b/docs/router-details.md
@@ -51,7 +51,7 @@ Jet Huang|Asia Pacific (Seoul)|seo-jhuang|52.220.234.177|seo-core-01|seo-esun
 Jim Lowe|US East (N. Virginia)|nov-jlowe|34.194.24.42|nov-core-01| 
 John Filo|Asia Pacific (Sydney)|syd-jfilo| |syd-core-01| 
 Ken Barr|US East (N. Virginia)|nov-kbarr| |nov-core-02| 
-Ken Overton|US East (N. Virginia)|nov-koverton|54.173.132.65|nov-core-02| 
+Ken Overton|US East (N. Virginia)|nov-koverton|34.194.147.103|nov-core-02| 
 Luis Horna|US East (N. Virginia)|nov-lhorna| |nov-core-01| 
 Magali Boulet|EU (Frankfurt)|frk-mboulet|35.156.182.14|frk-core-01|frk-tfairbairn|
 Mahesh Kaleru|US East (Ohio)|ohi-mkaleru| |ohi-core-01| 


### PR DESCRIPTION
whoops! sorry, didn't catch the bit about creating an elastic-IP. This version includes that address now.